### PR TITLE
fix(sts-client): don't allow an empty path into the request

### DIFF
--- a/src/aws-credentials/sts_client.cr
+++ b/src/aws-credentials/sts_client.cr
@@ -42,7 +42,8 @@ module Aws::Credentials
         form
       }
       endpoint_uri = URI.parse @endpoint
-      request = HTTP::Request.new "GET", endpoint_uri.path || "/"
+      endpoint_uri.path = "/" unless endpoint_uri.path.presence
+      request = HTTP::Request.new "GET", endpoint_uri.path
       request.headers["Host"] = endpoint_uri.host || raise "Endpoint#url is required"
       request.query = param
       signed_request = @signer.call(request, @contractor_credential_provider.credentials)
@@ -86,7 +87,8 @@ module Aws::Credentials
         form
       }
       endpoint_uri = URI.parse @endpoint
-      request = HTTP::Request.new "POST", endpoint_uri.path || "/"
+      endpoint_uri.path = "/" unless endpoint_uri.path.presence
+      request = HTTP::Request.new "POST", endpoint_uri.path
       request.headers["Host"] = endpoint_uri.host || raise "Endpoint#url is required"
       request.body = param
       # It is not required to sign this request


### PR DESCRIPTION
With the default URL, the path is effectively an empty string, which is not nil and is not replaced with `/`, producing weird requests like:

```
POST  HTTP/1.1
<...>
```